### PR TITLE
La til støtte for å konfigurere klientnavn og port for nedlastingsurl

### DIFF
--- a/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/GI/SakImportConfig.java
+++ b/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/GI/SakImportConfig.java
@@ -53,6 +53,7 @@ public class SakImportConfig {
     private String svarUtPassord;
     private String privateKeyFil;
     private String sakInnsynUrl;
+    private String sakKlientnavn;
 
     public SakImportConfig(String... args) {
         SvarUtCommandLineParser parser = new SvarUtCommandLineParser(args);
@@ -72,6 +73,7 @@ public class SakImportConfig {
         sakImportHostname = hentConfig(properties, cmdLine, KommandoParametre.SAK_IMPORT_HOSTNAME);
         sakDefaultSaksAar = hentConfig(properties, cmdLine, KommandoParametre.SAK_DEFAULT_SAKSAAR);
         sakDefaultSaksnr = hentConfig(properties, cmdLine, KommandoParametre.SAK_DEFAULT_SAKSNR);
+        sakKlientnavn = hentConfig(properties, cmdLine, KommandoParametre.SAK_KLIENTNAVN, "SVARUT");
         privateKeyFil = hentConfig(properties, cmdLine, KommandoParametre.PRIVATE_KEY_FIL);
         debug = cmdLine.hasOption(KommandoParametre.DEBUG.getValue());
 
@@ -80,6 +82,14 @@ public class SakImportConfig {
             ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("no");
             root.setLevel(Level.DEBUG);
         }
+    }
+
+    private String hentConfig(Properties properties, CommandLine cmdLine, KommandoParametre kommandoParametre, String defaultVerdi) {
+        String verdi = hentConfig(properties, cmdLine, kommandoParametre);
+        if (verdi == null) {
+            return defaultVerdi;
+        }
+        return verdi;
     }
 
     private String settPropertiesFilsti(CommandLine cmdLine) {
@@ -241,6 +251,10 @@ public class SakImportConfig {
         return sakDefaultSaksnr;
     }
 
+    public String getSakKlientnavn() {
+        return sakKlientnavn;
+    }
+
     public String getPrivateKeyFil() {
         return privateKeyFil;
     }
@@ -275,6 +289,7 @@ public class SakImportConfig {
                 ", sakImportHostname='" + sakImportHostname + '\'' +
                 ", sakDefaultSaksAar='" + sakDefaultSaksAar + '\'' +
                 ", sakDefaultSaksnr='" + sakDefaultSaksnr + '\'' +
+                ", sakKlientnavn='" + sakKlientnavn + '\'' +
                 ", debug=" + debug +
                 ", port=" + port +
                 ", urlSti='" + urlSti + '\'' +
@@ -307,4 +322,5 @@ public class SakImportConfig {
             throw new RuntimeException(e);
         }
     }
+
 }

--- a/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/GI/SakImportConfig.java
+++ b/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/GI/SakImportConfig.java
@@ -54,6 +54,7 @@ public class SakImportConfig {
     private String privateKeyFil;
     private String sakInnsynUrl;
     private String sakKlientnavn;
+    private String sakImportEksternPort;
 
     public SakImportConfig(String... args) {
         SvarUtCommandLineParser parser = new SvarUtCommandLineParser(args);
@@ -71,6 +72,7 @@ public class SakImportConfig {
         sakUrl = hentConfig(properties, cmdLine, KommandoParametre.SAK_URL);
         sakInnsynUrl = hentConfig(properties, cmdLine, KommandoParametre.SAK_INNSYN_URL);
         sakImportHostname = hentConfig(properties, cmdLine, KommandoParametre.SAK_IMPORT_HOSTNAME);
+        sakImportEksternPort = hentConfig(properties, cmdLine, KommandoParametre.SAK_IMPORT_EKSTERN_PORT, "9977");
         sakDefaultSaksAar = hentConfig(properties, cmdLine, KommandoParametre.SAK_DEFAULT_SAKSAAR);
         sakDefaultSaksnr = hentConfig(properties, cmdLine, KommandoParametre.SAK_DEFAULT_SAKSNR);
         sakKlientnavn = hentConfig(properties, cmdLine, KommandoParametre.SAK_KLIENTNAVN, "SVARUT");
@@ -287,6 +289,7 @@ public class SakImportConfig {
                 ", sakPassord='" + sakPassord + '\'' +
                 ", sakUrl='" + sakUrl + '\'' +
                 ", sakImportHostname='" + sakImportHostname + '\'' +
+                ", sakImportEksternPort='" + sakImportEksternPort + '\'' +
                 ", sakDefaultSaksAar='" + sakDefaultSaksAar + '\'' +
                 ", sakDefaultSaksnr='" + sakDefaultSaksnr + '\'' +
                 ", sakKlientnavn='" + sakKlientnavn + '\'' +
@@ -323,4 +326,7 @@ public class SakImportConfig {
         }
     }
 
+    public String getSakImportEksternPort() {
+        return sakImportEksternPort;
+    }
 }

--- a/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/GI/Saksimporter.java
+++ b/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/GI/Saksimporter.java
@@ -299,10 +299,10 @@ public class Saksimporter {
 
         final Filreferanse filinnhold = new Filreferanse();
         filinnhold.setFilnavn(filnavn);
-
+        String nedlastingssti = "http://" + sakImportConfig.getSakImportHostname() + ":" + sakImportConfig.getSakImportEksternPort();
         filinnhold.setMimeType(mimeType);
-        filinnhold.setUri("http://" + sakImportConfig.getSakImportHostname() + ":9977/forsendelse/" + forsendelseId);
-        filinnhold.setKvitteringUri("http://" + sakImportConfig.getSakImportHostname() + ":9977/kvitter/" + forsendelseId);
+        filinnhold.setUri(nedlastingssti + "/forsendelse/" + forsendelseId);
+        filinnhold.setKvitteringUri(nedlastingssti + "/kvitter/" + forsendelseId);
         dokument.setFil(filinnhold);
         final TilknyttetRegistreringSom value = new TilknyttetRegistreringSom();
         if (hoveddokument)

--- a/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/GI/Saksimporter.java
+++ b/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/GI/Saksimporter.java
@@ -42,7 +42,7 @@ public class Saksimporter {
     private org.slf4j.Logger log = LoggerFactory.getLogger(Saksimporter.class);
 
     public Saksimporter(SakImportConfig sakImportConfig) {
-        arkivKontekst.setKlientnavn("SVARUT");
+        arkivKontekst.setKlientnavn(sakImportConfig.getSakKlientnavn());
         url = sakImportConfig.getSakUrl();
         username = sakImportConfig.getSakBrukernavn();
         password = sakImportConfig.getSakPassord();

--- a/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/KommandoParametre.java
+++ b/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/KommandoParametre.java
@@ -11,6 +11,7 @@ public enum KommandoParametre {
     SAK_BRUKERNAVN("sakbrukernavn"),
     SAK_PASSORD("sakpassord"),
     SAK_IMPORT_HOSTNAME("hostname"),
+    SAK_IMPORT_EKSTERN_PORT("eksternport"),
     SAK_DEFAULT_SAKSAAR("saksaar"),
     SAK_DEFAULT_SAKSNR("saksnr"),
     SAK_KLIENTNAVN("sakklientnavn"),

--- a/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/KommandoParametre.java
+++ b/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/KommandoParametre.java
@@ -13,6 +13,7 @@ public enum KommandoParametre {
     SAK_IMPORT_HOSTNAME("hostname"),
     SAK_DEFAULT_SAKSAAR("saksaar"),
     SAK_DEFAULT_SAKSNR("saksnr"),
+    SAK_KLIENTNAVN("sakklientnavn"),
     PROPERTIES_FILSTI("konfigurasjonsfil"),
     PRIVATE_KEY_FIL("privatekeyfil"), DEBUG("debug"), SAK_INNSYN_URL("sakinnsynurl");
 

--- a/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/SvarUtCommandLineParser.java
+++ b/svarut-sak-import/src/main/java/no/ks/svarut/sakimport/SvarUtCommandLineParser.java
@@ -140,6 +140,17 @@ public class SvarUtCommandLineParser {
         options.add(OptionBuilder.withArgName(KommandoParametre.DEBUG.getValue())
                 .withDescription("Skru på debug logging")
                 .create(KommandoParametre.DEBUG.getValue()));
+
+        options.add(OptionBuilder.withArgName(KommandoParametre.SAK_KLIENTNAVN.getValue())
+                .hasArg()
+                .withDescription("Klientnavn til GeointegrasjonWebservice i saksystemet")
+                .create(KommandoParametre.SAK_KLIENTNAVN.getValue()));
+
+        options.add(OptionBuilder.withArgName(KommandoParametre.SAK_IMPORT_EKSTERN_PORT.getValue())
+                .hasArg()
+                .withDescription("Ekstern port for server til svarut-sak-import som saksystem kan nå den på.")
+                .create(KommandoParametre.SAK_IMPORT_EKSTERN_PORT.getValue()));
+
         return options;
     }
 }

--- a/svarut-sak-import/src/test/java/no/ks/svarut/sakimport/GI/TestParametre.java
+++ b/svarut-sak-import/src/test/java/no/ks/svarut/sakimport/GI/TestParametre.java
@@ -72,7 +72,7 @@ public class TestParametre {
         String sakinnsynurl = "http://localhost:8102/EphorteFakeService/innsynservice";
 
         return new String[]{"-svarutbrukernavn", brukernavn, "-svarutpassord", passord, "-svaruturl", url, "-sakurl", sakurl, "-sakinnsynurl", sakinnsynurl,
-                "-sakbrukernavn", "tull", "-sakpassord", "passord", "-hostname", "localhost", "-saksaar", "2014",
+                "-sakbrukernavn", "tull", "-sakpassord", "passord", "-sakklientnavn", "klient", "-hostname", "localhost", "-saksaar", "2014",
                 "-saksnr", "211", "-privatekeyfil", "sp-key.pem"};
     }
 

--- a/svarut-sak-import/src/test/java/no/ks/svarut/sakimport/GI/TestParametre.java
+++ b/svarut-sak-import/src/test/java/no/ks/svarut/sakimport/GI/TestParametre.java
@@ -73,7 +73,7 @@ public class TestParametre {
 
         return new String[]{"-svarutbrukernavn", brukernavn, "-svarutpassord", passord, "-svaruturl", url, "-sakurl", sakurl, "-sakinnsynurl", sakinnsynurl,
                 "-sakbrukernavn", "tull", "-sakpassord", "passord", "-sakklientnavn", "klient", "-hostname", "localhost", "-saksaar", "2014",
-                "-saksnr", "211", "-privatekeyfil", "sp-key.pem"};
+                "-saksnr", "211", "-privatekeyfil", "sp-key.pem", "-eksternport", "1234"};
     }
 
     @Test


### PR DESCRIPTION
- Vi måtte angi et annet klientnavn enn 'SVARUT' for arkivKontekst.klientnavn så vi kunne bruke lisensen vi alt hadde på geointegrasjons-tjenestene i ephorte. (Dersom en ikke angir noe brukes SVARUT)

- Ettersom vi kjører dette i docker er ikke port 9977 nåbar eksternt sånn uten videre, da er det mye greiere å kunne angi port selv. (Dersom en ikke angir noe brukes 9977)

OBS: Har ikke sjekket testene så nøye, kun fikset den som feilet.